### PR TITLE
Update syntax to freud v2

### DIFF
--- a/pythia/spherical_harmonics.py
+++ b/pythia/spherical_harmonics.py
@@ -71,7 +71,8 @@ def neighbor_average(box, positions, neigh_min=4, neigh_max=4, lmax=4,
         orientations[:, 0] = 1
 
     result = []
-    comp = freud.environment.LocalDescriptors(l_max=lmax, negative_m=negative_m, mode=reference_frame)
+    comp = freud.environment.LocalDescriptors(
+        l_max=lmax, negative_m=negative_m, mode=reference_frame)
 
     if nlist is None:
         nlist = _nlist_helper(freud_box, positions, neigh_max)

--- a/pythia/voronoi.py
+++ b/pythia/voronoi.py
@@ -72,11 +72,10 @@ def angle_histogram(box, positions, bins, buffer_distance=None, area_weight_mode
         buffer_distance = max(box.Lx, box.Ly, box.Lz)
 
     fbox = freud.box.Box.from_box(box)
-    voronoi = freud.voronoi.Voronoi(fbox, buff=buffer_distance)
-    voronoi.compute(positions)
+    voronoi = freud.locality.Voronoi()
+    voronoi.compute((fbox, positions))
 
-    all_polyhedra = voronoi.polytopes
-    polyhedra = [all_polyhedra[i] for i in range(len(positions))]
+    polyhedra = voronoi.polytopes
 
     result = np.zeros((len(positions), bins), dtype=np.float32)
     for (i, verts) in enumerate(polyhedra):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 numpy
 scipy
-freud-analysis
+freud-analysis>=2.0
 fsph

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ setup(name='pythia-learn',
       install_requires=[
           'numpy',
           'scipy',
-          'freud-analysis',
+          'freud-analysis>=2.0',
       ],
       license='BSD',
       long_description=long_description,

--- a/tests/test_bonds.py
+++ b/tests/test_bonds.py
@@ -42,10 +42,10 @@ class TestBonds(unittest.TestCase):
         # 1 and sqrt(2).
 
         idx_111 = 13
-        self.assertAlmostEquals(matrix[idx_111, 0, 0], 0)
+        self.assertAlmostEqual(matrix[idx_111, 0, 0], 0)
 
         # By definition of the noramlization.
-        self.assertAlmostEquals(matrix[idx_111, 0, 1], 1)
+        self.assertAlmostEqual(matrix[idx_111, 0, 1], 1)
 
         # By calculating distance and normalize by sqrt(2).
         np.testing.assert_almost_equal(matrix[idx_111, 0, 1:],
@@ -74,7 +74,7 @@ class TestBonds(unittest.TestCase):
         # 1 and sqrt(2).
 
         idx_111 = 13
-        self.assertAlmostEquals(matrix[idx_111, 0, 0], 0)
+        self.assertAlmostEqual(matrix[idx_111, 0, 0], 0)
 
         # By calculating distance and normalize by sqrt(2).
         np.testing.assert_almost_equal(matrix[idx_111, 0, 1:],

--- a/tests/test_bonds.py
+++ b/tests/test_bonds.py
@@ -81,5 +81,6 @@ class TestBonds(unittest.TestCase):
                                        np.array([1, 1, 1, 1, 2]) * np.pi / 2,
                                        decimal=4,)
 
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_voronoi.py
+++ b/tests/test_voronoi.py
@@ -29,5 +29,6 @@ class TestVoronoi(unittest.TestCase):
         np.testing.assert_equal(np.where(descriptors[idx_111])[0],
                                 np.array([0, bins//2, bins-1]))
 
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
I performed a minimal update of the syntax in pythia to use freud v2.0. This should not be merged until after the release of freud v2.0, which should be released by November 1.

Tests probably will not pass on CI until v2.0 is released.